### PR TITLE
BUILD-5391 setup pre commit validation at pr level

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Pre-commit checks
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@f04ea4aa921469a3f203f82f8965d3a308f59d91 # 0.0.7
+        with:
+          extra-args: >
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,14 +7,11 @@ on:
         required: true
         type: string
         description: "The Docker image to scan."
-        #    description: "Newline-delimited list of Docker images to scan"
-        default: "example/image_name:tag"
+        # i.e: "example/image_name:tag"
       filename:
         required: true
         type: string
         description: "The generated SBOM file name"
-        #    description: "Newline-delimited list of generated SBOM file names"
-        default: "bom.json"
       upload-artifact:
         required: false
         type: boolean

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -79,4 +79,3 @@ jobs:
           file_glob: true
           file: "${{ inputs.filename }}?(.asc)"
           tag: ${{ github.ref }}
-          overwrite: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -79,3 +79,4 @@ jobs:
           file_glob: true
           file: "${{ inputs.filename }}?(.asc)"
           tag: ${{ github.ref }}
+          overwrite: true

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  line_length: 120
+  tables: false
+
+# MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md031.md
+MD031:
+  # Disable for list_items to create a tight list containing a code fence
+  list_items: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,29 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
     hooks:
       - id: trailing-whitespace
-        args: [ --markdown-linebreak-ext=md ]
-      - id: end-of-file-fixer
-      - id: check-added-large-files
       - id: check-yaml
-      - id: check-json
-      - id: pretty-format-json
-        args: [--autofix, --indent, "4", --no-sort-keys]
-        files: ^.github/renovate.json
+      - id: check-added-large-files
+      - id: end-of-file-fixer
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.14.0
+    rev: 20447075e31543a8b125f2df18d75f3b5e7d4d2e # frozen: 0.22.0
     hooks:
-      - id: check-renovate
+      - id: check-github-workflows
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: 5341f388c2a962d3bc66e075f00b80ab45b15f24 # v0.1.20
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
+    hooks:
+      - id: markdownlint
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 32ee411cf36142e6082f10870ae62172ce9af133 # frozen: 35.32.0
+    hooks:
+      - id: renovate-config-validator
+  - repo: https://github.com/rhysd/actionlint
+    rev: 62dc61a45fc95efe8c800af7a557ab0b9165d63b # v1.7.1
+    hooks:
+      - id: actionlint

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
 ### GitHub Reusable Workflow
 
 :warning: The strategy property is not supported in any job that calls a reusable workflow.
-See https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations
+See [reusing workflows limitations](https://docs.github.com/en/actions/using-workflows/reusing-workflows#limitations)
 
 ```yaml
 jobs:
@@ -49,13 +49,13 @@ jobs:
 
 ## Versioning
 
-Using the versioned semantic [tags](#Tags) is recommended for security and reliability.
+Using the versioned semantic [tags](#tags) is recommended for security and reliability.
 
 See [GitHub: Using tags for release management](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management)
 and [GitHub: Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot)
 .
 
-For convenience, it is possible to use the [branches](#Branches) following the major releases.
+For convenience, it is possible to use the [branches](#branches) following the major releases.
 
 ### Tags
 
@@ -108,10 +108,9 @@ git push origin v1
 
 ### Warning Unexpected input
 
-> ```
 > Warning: Unexpected input(s) 'upload-artifact', 'upload-release-assets',
-> valid inputs are ['path', 'image', 'registry-username', 'registry-password', 'format', 'github-token', 'artifact-name', 'output-file', 'syft-version', 'dependency-snapshot']
-> ```
+> valid inputs are ['path', 'image', 'registry-username', 'registry-password', 'format', 'github-token',
+> 'artifact-name', 'output-file', 'syft-version', 'dependency-snapshot']
 
 The warning can be ignored, see anchore/sbom-action#269
 

--- a/action.yml
+++ b/action.yml
@@ -64,4 +64,3 @@ runs:
         file_glob: true
         file: "${{ inputs.filename }}?(.asc)"
         tag: ${{ github.ref }}
-        overwrite: true

--- a/action.yml
+++ b/action.yml
@@ -61,3 +61,4 @@ runs:
         file_glob: true
         file: "${{ inputs.filename }}?(.asc)"
         tag: ${{ github.ref }}
+        overwrite: true

--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,10 @@ inputs:
   image:
     required: true
     description: "The Docker image to scan."
-#    description: "Newline-delimited list of Docker images to scan"
-    default: "example/image_name:tag"
+    # i.e: "example/image_name:tag"
   filename:
     required: true
     description: "The generated SBOM file name"
-#    description: "Newline-delimited list of generated SBOM file names"
-    default: "bom.json"
   upload-artifact:
     required: false
     description: "Attach the SBOM to the workflow"
@@ -26,7 +23,7 @@ inputs:
     default: v0.105.0
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: anchore/sbom-action@e8d2a6937ecead383dfe75190d104edd1f9c5751 # v0.16.0
       with:

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ inputs:
   upload-artifact:
     required: false
     description: "Attach the SBOM to the workflow"
-    default: true
+    default: "true"
   upload-release-assets:
     required: false
     description: "Attach the SBOM to the release"
-    default: true
+    default: "true"
   syft-version:
     required: false
     description: "Syft version"


### PR DESCRIPTION
# BUILD-5391 setup pre commit validation at pr level

## Changes
* Enable pre-commit validation at PR level
* Update pre-commit-config so that it verify also github action and workflows (provides valuable inputs!)
* Fix issues so that any new contributor as of today do not have to fix earlier issues.