### PR TITLE
BUILD-11107 Support release-id input to attach SBOM to draft releases

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: false
     description: "Attach the SBOM to the release"
     default: "true"
+  release-id:
+    required: false
+    description: "GitHub release id to attach the SBOM to. Use instead of a tag when uploading to a draft release."
   syft-version:
     required: false
     description: "Syft version"
@@ -66,11 +69,12 @@ runs:
           ${{ inputs.filename }}.asc
         overwrite: true
     - name: Upload binaries to release
-      if: inputs.upload-release-assets == 'true' && startsWith(github.ref, 'refs/tags/')
+      if: inputs.upload-release-assets == 'true' && (inputs.release-id != '' || startsWith(github.ref, 'refs/tags/'))
       uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2
       with:
         repo_token: ${{ github.token }}
         file_glob: true
         file: "${{ inputs.filename }}?(.asc)"
-        tag: ${{ github.ref }}
+        release_id: ${{ inputs.release-id }}
+        tag: ${{ inputs.release-id == '' && github.ref || '' }}
         overwrite: true


### PR DESCRIPTION
## Summary

- Adds a `release-id` input to `gh-action_sbom`, forwarded to `svenstaro/upload-release-action`
- When `release-id` is provided, the upload step no longer requires a `refs/tags/` context, enabling SBOM attachment to GitHub **draft** releases
- Required by the draft-first v7 flow in [gh-action_release#feat/smarini/BUILD-11106-draft-first-v7](https://github.com/SonarSource/gh-action_release/pull/new/feat/smarini/BUILD-11106-draft-first-v7) (BUILD-11106/BUILD-11107)

## Test plan

- [ ] Call the action with `release-id` of a draft release → SBOM uploads to draft without requiring a tag ref
- [ ] Existing usage with `upload-release-assets: true` and a `refs/tags/` trigger → still works unchanged