### PR TITLE
BUILD-11107 Support GitHub Release Immutability

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,11 +1,6 @@
 name: Test action
 on:
   pull_request:
-  push:
-    branches: [ '**' ]
-  release:
-    types:
-      - created
   workflow_dispatch:
 
 jobs:
@@ -45,3 +40,55 @@ jobs:
           filename: test2-action-bom.json
           upload-artifact: false
           upload-release-assets: false
+
+  test-upload:
+    name: Test upload-release-assets
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: github-ubuntu-latest-s
+    env:
+      RELEASE_TAG: test/ci-sbom-${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: get secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+        with:
+          secrets: |
+            development/kv/data/sign passphrase | gpg_passphrase;
+            development/kv/data/sign key | gpg_key;
+      - name: Create temp tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
+      - uses: ./ # SonarSource/gh-action_sbom
+        with:
+          image: alpine:latest
+          filename: test-upload-bom.json
+          upload-artifact: true
+          upload-release-assets: true
+          release-tag: ${{ env.RELEASE_TAG }}
+        env:
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).gpg_passphrase }}
+          GPG_PRIVATE_KEY_BASE64: ${{ fromJSON(steps.secrets.outputs.vault).gpg_key }}
+      - name: Verify SBOM attached to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          assets=$(gh release view "$RELEASE_TAG" --json assets --jq '[.assets[].name]')
+          echo "Release assets: $assets"
+          echo "$assets" | jq -e 'map(select(. == "test-upload-bom.json")) | length > 0'
+          echo "$assets" | jq -e 'map(select(. == "test-upload-bom.json.asc")) | length > 0'
+      - name: Cleanup temp release and tag
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release delete "$RELEASE_TAG" --yes 2>/dev/null || true
+          gh api "repos/{owner}/{repo}/git/refs/tags/$RELEASE_TAG" --method DELETE 2>/dev/null || true

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -1,11 +1,6 @@
 name: Test reusable workflow
 on:
   pull_request:
-  push:
-    branches: [ '**' ]
-  release:
-    types:
-      - created
   workflow_dispatch:
 
 permissions:
@@ -29,3 +24,67 @@ jobs:
       filename: test-workflow-bom.json
       upload-artifact: false
       upload-release-assets: false
+
+  setup-upload-test:
+    name: Create temp tag for upload test
+    permissions:
+      contents: write
+    runs-on: github-ubuntu-latest-s
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Create temp tag
+        id: create-tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="test/ci-sbom-wf-$GITHUB_RUN_ID"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$tag"
+          git push origin "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  test-upload-workflow:
+    name: Test upload-release-assets (workflow)
+    needs: setup-upload-test
+    uses: ./.github/workflows/workflow.yml
+    with:
+      image: alpine:latest
+      filename: test-workflow-upload-bom.json
+      upload-artifact: true
+      upload-release-assets: true
+      release-tag: ${{ needs.setup-upload-test.outputs.tag }}
+    permissions:
+      contents: write
+      id-token: write
+
+  verify-and-cleanup:
+    name: Verify and cleanup upload test
+    needs: [setup-upload-test, test-upload-workflow]
+    if: always() && needs.setup-upload-test.result == 'success'
+    permissions:
+      contents: write
+    runs-on: github-ubuntu-latest-s
+    steps:
+      - name: Verify SBOM attached to release
+        if: needs.test-upload-workflow.result == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.setup-upload-test.outputs.tag }}
+        run: |
+          assets=$(gh release view "$TAG" --json assets --jq '[.assets[].name]')
+          echo "Release assets: $assets"
+          echo "$assets" | jq -e 'map(select(. == "test-workflow-upload-bom.json")) | length > 0'
+          echo "$assets" | jq -e 'map(select(. == "test-workflow-upload-bom.json.asc")) | length > 0'
+      - name: Cleanup temp release and tag
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.setup-upload-test.outputs.tag }}
+        run: |
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          gh api "repos/{owner}/{repo}/git/refs/tags/$TAG" --method DELETE 2>/dev/null || true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,8 +20,12 @@ on:
       upload-release-assets:
         required: false
         type: boolean
-        description: "Attach the SBOM to the release"
+        description: "Create release and attach the SBOM. Ignored if the release is already published (non-draft)."
         default: true
+      release-tag:
+        required: false
+        type: string
+        description: "Tag name of the release to attach the SBOM to. Defaults to the tag from GITHUB_REF. Use when the workflow is not running on a tag ref (e.g. workflow_dispatch from a branch)."
       syft-version:
         required: false
         type: string
@@ -52,6 +56,38 @@ jobs:
     runs-on: github-ubuntu-latest-s
 
     steps:
+      - name: Resolve upload-release-assets
+        id: check-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          INPUT_UPLOAD: ${{ inputs.upload-release-assets }}
+          INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          enabled="$INPUT_UPLOAD"
+          tag=""
+          if [[ "$INPUT_UPLOAD" == "true" ]]; then
+            if [[ -n "$INPUT_RELEASE_TAG" ]]; then
+              tag="$INPUT_RELEASE_TAG"
+            elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              tag="${GITHUB_REF#refs/tags/}"
+            else
+              echo "::warning::upload-release-assets is true but no release-tag input provided and not on a tag ref. SBOM not attached to release."
+              enabled="false"
+            fi
+          fi
+          if [[ "$enabled" == "true" && -n "$tag" ]]; then
+            if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+              if [[ "$is_draft" != "true" ]]; then
+                echo "::warning::Release '$tag' is already published (immutable). SBOM not attached to release. Use a draft-first workflow: create the release as a draft, run this action while it is still a draft, then publish."
+                enabled="false"
+              fi
+            else
+              gh release create "$tag" --draft --title "Release $tag"
+            fi
+          fi
+          echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
       - uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
         with:
           image: ${{ inputs.image }}
@@ -59,8 +95,8 @@ jobs:
           output-file: ${{ inputs.filename }}
           format: cyclonedx-json
           syft-version: ${{ inputs.syft-version }}
-          upload-artifact: ${{ inputs.upload-artifact }}
-          upload-release-assets: ${{ inputs.upload-release-assets }}
+          upload-artifact: false
+          upload-release-assets: false
           registry-username: ${{ inputs.registry-username }}
           registry-password: ${{ inputs.registry-password }}
         env:
@@ -94,12 +130,14 @@ jobs:
             ${{ inputs.filename }}
             ${{ inputs.filename }}.asc
           overwrite: true
-      - name: Upload binaries to release
-        if: inputs.upload-release-assets && startsWith(github.ref, 'refs/tags/')
-        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2
-        with:
-          repo_token: ${{ github.token }}
-          file_glob: true
-          file: "${{ inputs.filename }}?(.asc)"
-          tag: ${{ github.ref }}
-          overwrite: true
+      - name: Upload SBOM to release
+        if: steps.check-release.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SBOM_FILENAME: ${{ inputs.filename }}
+          RELEASE_TAG: ${{ steps.check-release.outputs.tag }}
+        run: |
+          files=("$SBOM_FILENAME")
+          [[ -f "${SBOM_FILENAME}.asc" ]] && files+=("${SBOM_FILENAME}.asc")
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Repositories needs to have access to the following secrets:
   development/kv/data/sign passphrase
   development/kv/data/sign key
 
+### Required permissions
+
+The calling job must grant:
+
+```yaml
+permissions:
+  contents: write  # create/update releases and upload assets
+```
+
 ### GitHub Action
 
 ```yaml
@@ -36,6 +45,7 @@ jobs:
           upload-release-assets: true
           registry-username: "username"
           registry-password: "password"
+          # release-tag: ${{ inputs.tag_name }}  # required when not running on a tag ref
         env:
           GPG_PRIVATE_KEY_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).gpg_passphrase }}
           GPG_PRIVATE_KEY_BASE64: ${{ fromJSON(steps.secrets.outputs.vault).gpg_key }}
@@ -55,6 +65,39 @@ jobs:
       filename: bom.json
       upload-artifact: true
       upload-release-assets: true
+      # release-tag: ${{ inputs.tag_name }}  # required when not running on a tag ref
+```
+
+### GitHub Release Immutability
+
+When GitHub Release Immutability is enforced, assets cannot be uploaded to a published release (HTTP 422).
+
+#### Draft-first workflow (required)
+
+1. Run this action — it creates a draft release for the resolved tag (if none exists) and attaches the SBOM and its GPG signature.
+2. Publish the release after the workflow completes.
+
+If the release is already published, the action skips the SBOM upload with a warning.
+
+#### Running from a branch ref (e.g. `workflow_dispatch`)
+
+When the workflow is not triggered from a tag ref, `GITHUB_REF` does not point to a tag.
+Pass the tag explicitly via the `release-tag` input:
+
+```yaml
+      - uses: SonarSource/gh-action_sbom@v1
+        with:
+          image: example/image_name:tag
+          filename: bom.json
+          upload-release-assets: true
+          release-tag: ${{ inputs.tag_name }}
+        env:
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).gpg_passphrase }}
+          GPG_PRIVATE_KEY_BASE64: ${{ fromJSON(steps.secrets.outputs.vault).gpg_key }}
+      # ... after all assets are attached:
+      - run: gh release edit "${{ inputs.tag_name }}" --draft=false
+        env:
+          GH_TOKEN: ${{ github.token }}
 ```
 
 ## Versioning

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,11 @@ inputs:
     default: "true"
   upload-release-assets:
     required: false
-    description: "Attach the SBOM to the release"
+    description: "Create release and attach the SBOM. Ignored if the release is already published (non-draft)."
     default: "true"
+  release-tag:
+    required: false
+    description: "Tag name of the release to attach the SBOM to. Defaults to the tag from GITHUB_REF. Use when the workflow is not running on a tag ref (e.g. workflow_dispatch from a branch)."
   syft-version:
     required: false
     description: "Syft version"
@@ -33,6 +36,39 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve upload-release-assets
+      id: check-release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        INPUT_UPLOAD: ${{ inputs.upload-release-assets }}
+        INPUT_RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        enabled="$INPUT_UPLOAD"
+        tag=""
+        if [[ "$INPUT_UPLOAD" == "true" ]]; then
+          if [[ -n "$INPUT_RELEASE_TAG" ]]; then
+            tag="$INPUT_RELEASE_TAG"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tag="${GITHUB_REF#refs/tags/}"
+          else
+            echo "::warning::upload-release-assets is true but no release-tag input provided and not on a tag ref. SBOM not attached to release."
+            enabled="false"
+          fi
+        fi
+        if [[ "$enabled" == "true" && -n "$tag" ]]; then
+          if is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft' 2>/dev/null); then
+            if [[ "$is_draft" != "true" ]]; then
+              echo "::warning::Release '$tag' is already published (immutable). SBOM not attached to release. Use a draft-first workflow: create the release as a draft, run this action while it is still a draft, then publish."
+              enabled="false"
+            fi
+          else
+            gh release create "$tag" --draft --title "Release $tag"
+          fi
+        fi
+        echo "enabled=$enabled" >> "$GITHUB_OUTPUT"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
     - uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
       with:
         image: ${{ inputs.image }}
@@ -40,8 +76,8 @@ runs:
         output-file: ${{ inputs.filename }}
         format: cyclonedx-json
         syft-version: ${{ inputs.syft-version }}
-        upload-artifact: ${{ inputs.upload-artifact }}
-        upload-release-assets: ${{ inputs.upload-release-assets }}
+        upload-artifact: false
+        upload-release-assets: false
         registry-username: ${{ inputs.registry-username }}
         registry-password: ${{ inputs.registry-password }}
       env:
@@ -65,12 +101,15 @@ runs:
           ${{ inputs.filename }}
           ${{ inputs.filename }}.asc
         overwrite: true
-    - name: Upload binaries to release
-      if: inputs.upload-release-assets == 'true' && startsWith(github.ref, 'refs/tags/')
-      uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2
-      with:
-        repo_token: ${{ github.token }}
-        file_glob: true
-        file: "${{ inputs.filename }}?(.asc)"
-        tag: ${{ github.ref }}
-        overwrite: true
+    - name: Upload SBOM to release
+      if: steps.check-release.outputs.enabled == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        SBOM_FILENAME: ${{ inputs.filename }}
+        RELEASE_TAG: ${{ steps.check-release.outputs.tag }}
+      run: |
+        files=("$SBOM_FILENAME")
+        [[ -f "${SBOM_FILENAME}.asc" ]] && files+=("${SBOM_FILENAME}.asc")
+        gh release upload "$RELEASE_TAG" "${files[@]}" --clobber


### PR DESCRIPTION
## Summary

- Add `release-tag` input so callers not running on a tag ref (e.g. `workflow_dispatch` from a branch) can pass the tag explicitly
- Add pre-check step (`check-release`) that runs before `anchore/sbom-action` to resolve the tag, auto-create a draft release if none exists, and block upload (with a warning) if the release is already published
- Replace `svenstaro/upload-release-action` with `gh release upload --clobber` to avoid HTTP 422 errors when uploading to immutable (published) releases

## Immutability pattern

The recommended workflow:
1. Create the release as a draft
2. Run this action (it attaches the SBOM while the release is still a draft)
3. Publish the release

If a release is already published when this action runs, it emits a warning and skips the upload rather than failing.

## References

- https://sonarsource.atlassian.net/browse/BUILD-11107

## Test plan

- [ ] Run on a workflow that uses `workflow_dispatch` and passes `release-tag` — verify SBOM is attached to the draft release
- [ ] Run on a tag ref without a pre-existing release — verify a draft release is auto-created and SBOM is attached
- [ ] Run against an already-published release — verify a warning is emitted and the workflow does not fail