### PR TITLE
BUILD-10835 Migrate GitHub-hosted Ubuntu runners to warp-custom-ubuntu-24-04

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pre-commit:
     name: "pre-commit"
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: SonarSource/gh-action_pre-commit@0ecedc4e4070444a95f6b6714ddc3ebcdde697c4 # 1.1.0
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -9,7 +9,7 @@ jobs:
       id-token: write
       contents: write
     name: Test SonarSource/gh-action_sbom on alpine:latest
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: get secrets
         id: secrets
@@ -46,7 +46,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     env:
       RELEASE_TAG: test/ci-sbom-${{ github.run_id }}
     steps:

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -29,7 +29,7 @@ jobs:
     name: Create temp tag for upload test
     permissions:
       contents: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     outputs:
       tag: ${{ steps.create-tag.outputs.tag }}
     steps:
@@ -66,7 +66,7 @@ jobs:
     if: always() && needs.setup-upload-test.result == 'success'
     permissions:
       contents: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Verify SBOM attached to release
         if: needs.test-upload-workflow.result == 'success'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -53,7 +53,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
 
     steps:
       - name: Resolve upload-release-assets


### PR DESCRIPTION
BUILD-10835 This change moves CI from GitHub-hosted Ubuntu runner labels to the shared WarpBuild image `warp-custom-ubuntu-24-04`, in line with the platform runner migration.

## Summary

- Replaces `github-ubuntu-latest-*` with `warp-custom-ubuntu-24-04` in the workflows listed in the migration scan.

## Files

- `.github/workflows/pre-commit.yml`
- `.github/workflows/test-action.yml`
- `.github/workflows/test-workflow.yml`
- `.github/workflows/workflow.yml`

## Notes for reviewers

- No intentional changes to job logic, permissions, or steps beyond `runs-on` / default runner strings.
- Please confirm workflows still match org expectations for this repository after merge.
